### PR TITLE
v3 update

### DIFF
--- a/contracts/CHEEL.sol
+++ b/contracts/CHEEL.sol
@@ -8,8 +8,11 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 contract CHEEL is ERC20, Ownable, ERC20Permit, ERC20Votes {
     uint256 public constant MAX_AMOUNT = 10**9 * 10**18;
+    address public gnosis = address(0);
 
-    constructor() ERC20("CHEELEE", "CHEEL") ERC20Permit("CHEELEE") {}
+    constructor() ERC20("CHEELEE", "CHEEL") ERC20Permit("CHEELEE") {
+        transferOwnership(gnosis);
+    }
 
     function _afterTokenTransfer(
         address _from,

--- a/contracts/LEE.sol
+++ b/contracts/LEE.sol
@@ -7,11 +7,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract LEE is ERC20, ERC20Permit, Ownable {
     uint256 public constant MAX_AMOUNT = 7 * 10**9 * 10**18;
+    address public gnosis = address(0);
 
-    constructor()
-        ERC20("CHEELE Attention Token", "LEE")
-        ERC20Permit("LEE")
-    {}
+    constructor() ERC20("CHEELE Attention Token", "LEE") ERC20Permit("LEE") {
+        transferOwnership(gnosis);
+    }
 
     function mint(address _to, uint256 _amount) external onlyOwner {
         require(

--- a/contracts/MultiVesting.sol
+++ b/contracts/MultiVesting.sol
@@ -13,26 +13,30 @@ contract MultiVesting is IVesting, Ownable {
     event Vested(address beneficiary, uint256 amount);
     event EmergencyVest(uint256 amount);
     event UpdateBeneficiary(address oldBeneficiary, address newBeneficiary);
+    event DisableEarlyWithdraw(address owner);
 
     IERC20 public immutable token;
     address public seller;
+    address public gnosis = address(0);
 
     mapping(address => uint256) public released;
     mapping(address => Beneficiary) public beneficiary;
 
-    bool public changeBenificiaryAllowed;
+    bool public changeBeneficiaryAllowed;
     bool public earlyWithdrawAllowed;
 
     constructor(
         IERC20 _token,
-        bool _changeBenificiaryAllowed,
+        bool _changeBeneficiaryAllowed,
         bool _earlyWithdrawAllowed
     ) {
         require(address(_token) != address(0), "Can't set zero address");
         token = _token;
 
-        changeBenificiaryAllowed = _changeBenificiaryAllowed;
+        changeBeneficiaryAllowed = _changeBeneficiaryAllowed;
         earlyWithdrawAllowed = _earlyWithdrawAllowed;
+
+        transferOwnership(gnosis);
     }
 
     function setSeller(address _addr) external onlyOwner {
@@ -159,7 +163,7 @@ contract MultiVesting is IVesting, Ownable {
     function updateBeneficiary(address _oldBeneficiary, address _newBeneficiary)
         external
     {
-        require(changeBenificiaryAllowed, "Option not allowed");
+        require(changeBeneficiaryAllowed, "Option not allowed");
         require(
             msg.sender == owner() || msg.sender == _oldBeneficiary,
             "Not allowed to change"
@@ -184,5 +188,7 @@ contract MultiVesting is IVesting, Ownable {
 
     function disableEarlyWithdraw() external onlyOwner {
         earlyWithdrawAllowed = false;
+
+        emit DisableEarlyWithdraw(msg.sender);
     }
 }

--- a/contracts/NFT.sol
+++ b/contracts/NFT.sol
@@ -17,6 +17,7 @@ contract NFT is ERC721, ERC721Enumerable, CustomNFT, Ownable {
 
     address public nftSale;
     address public treasury;
+    address public gnosis = address(0);
 
     string public baseUri;
 
@@ -25,6 +26,8 @@ contract NFT is ERC721, ERC721Enumerable, CustomNFT, Ownable {
     {
         NAME = _name;
         VERSION = _version;
+
+        transferOwnership(gnosis);
     }
 
     function receiveNFT(address _to, uint256 _tokenId) external override {

--- a/contracts/NFTSale.sol
+++ b/contracts/NFTSale.sol
@@ -30,6 +30,7 @@ contract NFTSale is EIP712, Ownable {
         );
 
     address public signer;
+    address public gnosis = address(0);
     CustomNFT public nftContract;
 
     mapping(address => bool) public usedRedeemSignature;
@@ -59,6 +60,8 @@ contract NFTSale is EIP712, Ownable {
         pricePerToken = _pricePerToken;
         redeemSupply = _redeemSupply;
         purchaseSupply = _purchaseSupply;
+
+        transferOwnership(gnosis);
     }
 
     function setRedeemSupply(uint256 _newRedeemSupply) external onlyOwner {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -9,8 +9,19 @@ contract Staking is Ownable {
     using SafeERC20 for IERC20;
 
     event SetOptionState(uint256 option, bool state);
-    event SetOption(uint256 option, uint256 lockPeriod, uint256 apy, uint256 minValue, uint256 maxValue);
-    event AddOption(uint256 lockPeriod, uint256 apy, uint256 minValue, uint256 maxValue);
+    event SetOption(
+        uint256 option,
+        uint256 lockPeriod,
+        uint256 apy,
+        uint256 minValue,
+        uint256 maxValue
+    );
+    event AddOption(
+        uint256 lockPeriod,
+        uint256 apy,
+        uint256 minValue,
+        uint256 maxValue
+    );
 
     IERC20 public immutable token;
 
@@ -39,10 +50,13 @@ contract Staking is Ownable {
 
     mapping(address => bool) public registeredUserMap;
     address[] public registeredUsers;
+    address public gnosis = address(0);
 
     constructor(IERC20 _token) {
         require(address(_token) != address(0), "Can't set zero address");
         token = _token;
+
+        transferOwnership(gnosis);
     }
 
     function getRegisteredUsersSize() external view returns (uint256) {
@@ -96,7 +110,7 @@ contract Staking is Ownable {
         apy.push(_apy);
         minAmount.push(_minValue);
         maxAmount.push(_maxValue);
-        
+
         emit AddOption(_lockPeriod, _apy, _minValue, _maxValue);
     }
 

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -51,6 +51,7 @@ contract Treasury is
     uint256[] public maxTokenTransferPerDay;
 
     address public signer;
+    address public gnosis = address(0);
     IERC20Upgradeable[] public tokens;
     CustomNFT[] public nfts;
 
@@ -98,6 +99,8 @@ contract Treasury is
 
         nfts[0].setApprovalForAll(address(nfts[0]), true);
         nfts[1].setApprovalForAll(address(nfts[1]), true);
+
+        transferOwnership(gnosis);
     }
 
     function verifySignature(


### PR DESCRIPTION
4 critical - centralization
--------------------------
The boolean variable earlyWithdrawAllowed is assigned a value in the constructor and the function disableEarlyWithdraw() can be used to set it equal to False, however, there is no function present to make it true again once disableEarlyWithdraw() is called. If earlyWithdrawAllowed is false, then the function emergencyVest() can never be called. We believe there should be a function that can be used to toggle the value of this variable.

For example,disableEarlyWithdraw() can be changed to:

    event EarlyWithdrawAllowed(bool status);

    function toggleEarlyWithdrawAllowed(bool status) external onlyOwner {
        earlyWithdrawAllowed = status;
        emit EarlyWithdrawAllowed(status);
    }
--------------------------------
MVC-03 | Contract `MultiVesting` Has No Balance
--------------------------------
Alleviation
[CertiK]: Partially resolved in commits:

[2b4ac125c884222c468093f6331a57a52218b69e](https://github.com/Cheelee-inc/smartcontracts/commit/2b4ac125c884222c468093f6331a57a52218b69e)
[376ed125e8954d640c28ed7c6dcfa5b15a86d8d7](https://github.com/Cheelee-inc/smartcontracts/commit/376ed125e8954d640c28ed7c6dcfa5b15a86d8d7)
The updated commit introduced new functions to the codebase which also lack the emitting of events for sensitive functions.
In the contract MultiVesting.sol, the following function should emit an event:

disableEarlyWithdraw()
--------------------------------
Typos
Alleviation
[CertiK]: Partially resolved in the following commits:

[2b4ac125c884222c468093f6331a57a52218b69e](https://github.com/Cheelee-inc/smartcontracts/commit/2b4ac125c884222c468093f6331a57a52218b69e)
[376ed125e8954d640c28ed7c6dcfa5b15a86d8d7](https://github.com/Cheelee-inc/smartcontracts/commit/376ed125e8954d640c28ed7c6dcfa5b15a86d8d7)
In LEE.sol, "CHEELEE" is still misspelled in the constructor as "CHEELE"

Additionally, the updated codebase introduced a new spelling error in the contract MultiVesting.sol. The variable changeBenificiaryAllowed is misspelled and should be changed to changeBeneficiaryAllowed
